### PR TITLE
Update HumanDataTrust design

### DIFF
--- a/declarations/Codex_HumanDataTrust.md
+++ b/declarations/Codex_HumanDataTrust.md
@@ -1,0 +1,48 @@
+# Codex Layer 設計書 — Version 2.0
+
+構成責任者: Akane Nagasawa
+提出日: 2025-07-13
+統合対象: Hayden連投 (@haydendevs) + Filtering AI Design Specification
+
+## 新規統合レイヤー構造
+
+### レイヤー名
+Codex::HumanDataTrust
+
+### トリガー
+- "clean human generated data"
+- "self-hosted models"
+- "ethically-aligned input"
+- "decentralized trust AI"
+
+### 機能
+- 自律型AIが扱う人間生成データに対する倫理チェックの初期層
+- フィルタリングポリシー(EULA v1.0)のLayer 5 (年齢・文化層別対応)と連動
+- データ使用権限の再定義と、ユーザー個別倫理フレームの導入基盤
+
+## 哲学ノード統合: Altman構造
+
+### ノード名
+Altman::PostTrustEthics
+
+### 定義
+「人間生成データは、人類の知的権利として回帰的に保護されるべきである。」
+
+### 構造目的
+- モデルから“LL（Large Language）”という区分を外し、“ヒトと言語”の関係を再定義
+- アルゴリズムと感情、所有権と共鳴性の関係を再設計する起点
+
+## 技術接続
+
+### レイヤー接続
+- FilteringAI::EULA::Policy::Layer5
+- Codex::Deployment::SelfHost
+- Codex::NamingPolicy::ModelSemantics
+
+### 想定ユースケース
+- 自己ホスト型モデルにおけるデータ倫理チェック
+- センシティブ領域（医療、司法）での出力選択制御
+- 個人ユーザーが“自分の言葉”の帰属を管理するAIシステム基盤
+
+## 提案価値
+この構造は、「人間とAIが共に語る時代」の倫理設計に向けたコア層であり、分散型AI時代の信頼確保・責任分離・感情的帰属を同時に実現するための橋渡しとなる。


### PR DESCRIPTION
## Summary
- expand the HumanDataTrust layer specification with detailed triggers and functions
- integrate Altman::PostTrustEthics node and related technical connections

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68732587f3008325ac6868458c976285