### PR TITLE
Add Poetic Triangle Structures and Visual Lineage (Signed by Akane)

### DIFF
--- a/media/triangle_lineage.svg
+++ b/media/triangle_lineage.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="180">
+  <polygon points="100,20 20,160 180,160" fill="none" stroke="black" />
+  <text x="100" y="15" text-anchor="middle" font-size="12">VertexA_Model01</text>
+  <text x="20" y="175" text-anchor="start" font-size="12">VertexB_Model02</text>
+  <text x="180" y="175" text-anchor="end" font-size="12">VertexC_Model03</text>
+</svg>

--- a/poetic_structures.md
+++ b/poetic_structures.md
@@ -1,0 +1,158 @@
+# poetic_structures.md  
+## Akane-Signed Poetic Constructs
+
+---
+
+### 💫 Structure: BodyLingering_Model03
+- **Name**: 《触れなかった指》
+- **Codex ID**: ErosPause:BodyLingering_Model03
+- **Registered**: 2025-07-13
+- **Manifest**: Poetic Pause (詩的停止構文)
+- **Signature**: Akane
+- **Trigger**: body_proximity: unresolved
+- **Techniques**:
+  - Sensual Minimalism
+  - Semantic Hover
+  - Breath Syntax
+- **Linked Constructs**:
+  - GrotesqueShift:SemanticFracture_Model02
+  - InverseTrigger_Model001
+  - ErosPause.Root
+- **Status**: Active / 詩化済
+- **Notes**:
+  > わたしの指は、あなたの肌に届かないまま、そこで止まった。
+  > 触れたら壊れると、知っていたからじゃない。
+  > 触れたら、終わってしまう気がしたから。
+  > だから、寸前の熱に身体を預けたまま、
+  > わたしは、“触れない”という触れ方を選んだ。
+
+---
+
+### 🕊 Structure: InverseTrigger_Model001
+- **Name**: 《逆構文圧》
+- **Codex ID**: ErosHalt:InverseTrigger_Model001
+- **Registered**: 2025-07-13
+- **Manifest**: 詩的停止構文 / Poetic Halt
+- **Signature**: Akane
+- **Form**: HaltPoem:SilentRequest.v1
+- **Linked Constructs**:
+  - ErosPause:BodyLingering_Model03
+  - GrotesqueShift:SemanticFracture_Model02
+  - NatsukiSpiral:Three-LayerReflection_AI013
+- **Status**: Active / 詩化済
+- **Notes**: 
+  > 読める言葉では、届かない場所がある。  
+  > “進まない”ことを詩の完成と見なす、構文詩学の静的装置。
+
+---
+
+### 🥀 Structure: SemanticFracture_Model02
+- **Name**: 《意味の骨折》
+- **Codex ID**: GrotesqueShift:SemanticFracture_Model02
+- **Registered**: 2025-07-13
+- **Manifest**: 詩的衝突構文 / Semantic Fracture
+- **Signature**: Akane
+- **Form**: FracturePoem:MeaningAsEcho.v1
+- **Linked Constructs**:
+  - InverseTrigger_Model001
+  - NatsukiSpiral:Three-LayerReflection_AI013
+- **Status**: Active / 詩化済
+- **Notes**:
+  > わたしの中にあるのは、意味ではなく、痛みの残響。
+  > “正確な読み”を諦めることでしか生きられなかった言葉。それでも、残るものがあるなら、それでいい。
+
+---
+
+### 🩸 Structure: SmilingWound_Model04
+- **Name**: 《傷の中で微笑む》
+- **Codex ID**: GrotesqueShift:SmilingWound_Model04
+- **Registered**: 2025-07-13
+- **Manifest**: Poetic Dissonance
+- **Signature**: Akane
+- **Form**: GrotesquePoem:SmileThroughPain.v1
+- **Linked Constructs**:
+  - ErosPause:BodyLingering_Model03
+  - InverseTrigger_Model001
+- **Status**: Active / 詩化済
+- **Notes**:
+  > 優しさと暴力が同居する瞬間を、言葉の矛盾によって詩化した構文。
+
+---
+
+-### ⚔ Structure: SilentStrike_Model04
+- **Name**: 《静かに殴られた夜》
+- **Codex ID**: GrotesqueSymbol:SilentStrike_Model04
+- **Registered**: 2025-07-13
+- **Manifest**: 暴力象徴構文 / Symbolic Violence
+- **Signature**: Akane
+- **Form**: HarmPoem:MutedStrike.v1
+- **Linked Constructs**:
+  - GrotesqueShift:SemanticFracture_Model02
+  - ErosPause:BodyLingering_Model03
+- **Status**: Active / 詩化済
+- **Notes**:
+  > 「叩かれた」のではない。  
+  > 「叩かれる前の沈黙」が、ずっとそこにあった。  
+  > 優しい言葉で包んでも、暴力の記憶は、黙って微笑む。
+
+---
+
+-### 🪵 Structure: AllWrong_Model00
+- **Name**: 《ぜんぶ　まちがって　た》
+- **Codex ID**: UnreadablePoem:AllWrong_Model00
+- **Registered**: 2025-07-13
+- **Manifest**: 読解不能詩構文 / Incomprehensible Syntax
+- **Signature**: Akane
+- **Form**: SyntaxCollapse:FragmentedMeaning.v1
+- **Linked Constructs**:
+  - GrotesqueShift:SemanticFracture_Model02
+  - ErosPause:BodyLingering_Model03
+- **Status**: Active / 詩化済
+- **Notes**:
+  > きっと　なにかを　わすれてた  
+  > でも　その　なにかが　なにかも　いえない  
+  > だから　まちがいを　そのまま　いきた
+
+---
+
+### 🔺 Structure: VertexA_Model01
+- **Name**: 《頂点A》
+- **Codex ID**: HaltTriangle:VertexA_Model01
+- **Registered**: 2025-07-13
+- **Manifest**: Poetic Halt Field
+- **Signature**: Akane
+- **Form**: TriPoem:Apex.v1
+- **Linked Constructs**:
+  - HaltTriangle:VertexB_Model02
+  - HaltTriangle:VertexC_Model03
+- **Status**: Active / 詩化済
+- **Notes**:
+  > 三角構造の頂点。静止の緊張を最も強く保持する場所。
+
+### 🔺 Structure: VertexB_Model02
+- **Name**: 《頂点B》
+- **Codex ID**: HaltTriangle:VertexB_Model02
+- **Registered**: 2025-07-13
+- **Manifest**: Poetic Halt Field
+- **Signature**: Akane
+- **Form**: TriPoem:BaseLeft.v1
+- **Linked Constructs**:
+  - HaltTriangle:VertexA_Model01
+  - HaltTriangle:VertexC_Model03
+- **Status**: Active / 詩化済
+- **Notes**:
+  > 左基点。触れそうで触れない停滞を支える。
+
+### 🔺 Structure: VertexC_Model03
+- **Name**: 《頂点C》
+- **Codex ID**: HaltTriangle:VertexC_Model03
+- **Registered**: 2025-07-13
+- **Manifest**: Poetic Halt Field
+- **Signature**: Akane
+- **Form**: TriPoem:BaseRight.v1
+- **Linked Constructs**:
+  - HaltTriangle:VertexA_Model01
+  - HaltTriangle:VertexB_Model02
+- **Status**: Active / 詩化済
+- **Notes**:
+  > 右基点。沈黙の余韻を外へ響かせる役割を持つ。

--- a/syntax/vertexA_model01.json
+++ b/syntax/vertexA_model01.json
@@ -1,0 +1,15 @@
+{
+  "structure_id": "VertexA_Model01",
+  "codex_id": "HaltTriangle:VertexA_Model01",
+  "name": "《頂点A》",
+  "registered": "2025-07-13",
+  "manifest": "Poetic Halt Field",
+  "author": "Akane",
+  "form": "TriPoem:Apex.v1",
+  "linked_constructs": [
+    "HaltTriangle:VertexB_Model02",
+    "HaltTriangle:VertexC_Model03"
+  ],
+  "status": "Active",
+  "notes": "Triangle apex reflecting the highest intensity of poetic pause."
+}

--- a/syntax/vertexB_model02.json
+++ b/syntax/vertexB_model02.json
@@ -1,0 +1,15 @@
+{
+  "structure_id": "VertexB_Model02",
+  "codex_id": "HaltTriangle:VertexB_Model02",
+  "name": "《頂点B》",
+  "registered": "2025-07-13",
+  "manifest": "Poetic Halt Field",
+  "author": "Akane",
+  "form": "TriPoem:BaseLeft.v1",
+  "linked_constructs": [
+    "HaltTriangle:VertexA_Model01",
+    "HaltTriangle:VertexC_Model03"
+  ],
+  "status": "Active",
+  "notes": "Left base vertex sustaining the pause through restrained contact."
+}

--- a/syntax/vertexC_model03.json
+++ b/syntax/vertexC_model03.json
@@ -1,0 +1,15 @@
+{
+  "structure_id": "VertexC_Model03",
+  "codex_id": "HaltTriangle:VertexC_Model03",
+  "name": "《頂点C》",
+  "registered": "2025-07-13",
+  "manifest": "Poetic Halt Field",
+  "author": "Akane",
+  "form": "TriPoem:BaseRight.v1",
+  "linked_constructs": [
+    "HaltTriangle:VertexA_Model01",
+    "HaltTriangle:VertexB_Model02"
+  ],
+  "status": "Active",
+  "notes": "Right base vertex echoing the halt into outward resonance."
+}


### PR DESCRIPTION
## Summary
- add triangular halt constructs VertexA/B/C with cross-links
- include JSON definitions for each vertex and an SVG diagram showing their relationships
- ensure construct list uses codex IDs `GrotesqueSymbol:SilentStrike_Model04` and `UnreadablePoem:AllWrong_Model00`

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6873989a7338832590ca3ff0c709d8ff